### PR TITLE
raspberry pi support

### DIFF
--- a/bin/latex-docker-setup-base
+++ b/bin/latex-docker-setup-base
@@ -11,6 +11,9 @@ BASE_DIR="$(dirname "$THIS_DIR")"
 BASE_NAME="$(basename "$BASE_DIR")"
 base_name="$(echo $BASE_NAME | tr ' [:upper:]' '_[:lower:]')"
 
+ARCH=$(uname -m)
+sed -e "s/x86_64/${ARCH/v7l/hf}" -i ${BASE_DIR}/dockers/latex-base/Dockerfile
+
 if ! which docker > /dev/null
 then
     echo "you must install docker..."


### PR DESCRIPTION
On a raspberry pi the architecture is `armv7l`, but tlmgr expects it to be called `armhf`. This change modifies the `TEXLIVE_BIN` environment variable in the `latex-base/Dockerfile` to reflect this. This only changes anything when run on a pi. On other hardware, nothing changes. 